### PR TITLE
Fix block mismatch in Start-NancyHost.ps1

### DIFF
--- a/src/public/Start-NancyHost.ps1
+++ b/src/public/Start-NancyHost.ps1
@@ -73,8 +73,8 @@
         ${script:Nancy Nancy Server}.Start();
 
         # Open it in the browser to prove it works
-            Start-Process ${script:Nancy Uri}
-            Write-Host "Nancy running on ${script:Nancy Uri}, call Stop-NancyHost to stop it"
-        }
+        Start-Process ${script:Nancy Uri}
+        Write-Host "Nancy running on ${script:Nancy Uri}, call Stop-NancyHost to stop it"
+        
     }
 }


### PR DESCRIPTION
There seems to be one too many } symbols in the source code for Start-NancyHost.ps1 . I've taken out what I believe is the extra symbol, and adjusted the indentation on a couple of lines to support this change. I couldn't get the module to load without making this change.