### PR TITLE
Get-NancyHandler typo fix

### DIFF
--- a/src/public/Start-NancyHost.ps1
+++ b/src/public/Start-NancyHost.ps1
@@ -61,7 +61,7 @@
             [NancyPS.StaticBootstrapper]::DiagnosticsPassword = $DiagnosticsPassword
         }
 
-        if(!(Get-NancyHander)){
+        if(!(Get-NancyHandler)){
             # If they call Start without having any handlers, let's at least add a base one
             Set-NancyHandler -Path "/" -Handler { "Welcome to Nancy" }
         }


### PR DESCRIPTION
Changed "if(!(Get-NancyHander))" to "if(!(Get-NancyHandler))" . Was receiving an error message when running Start-NancyHost without this fix.