### PR TITLE
Remove unrecognised Resolve-Path parameter

### DIFF
--- a/src/public/Set-NancyRoot.ps1
+++ b/src/public/Set-NancyRoot.ps1
@@ -9,7 +9,7 @@ function Set-NancyRoot {
         [string]$Path
     )
     process {
-        $ResolvedPath = Resolve-Path $Path -PathType Container -ErrorAction Stop
+        $ResolvedPath = Resolve-Path $Path -ErrorAction Stop
         if($ResolvedPath.Provider.Name -ne "FileSystem")
         {
             throw "The Nancy root must be a folder path that exists on the FileSystem"


### PR DESCRIPTION
Removed "-PathType Container" parameter from Resolve-Path, as it doesn't exist as an option for this command.
https://docs.microsoft.com/en-gb/powershell/module/Microsoft.PowerShell.Management/Resolve-Path?view=powershell-5.1